### PR TITLE
docs: removed template base docs header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Vue 3 + TypeScript + Vite + Vuetify + Vue Router
+# Lichess Stats Visualizer
 
-This template should help get you started developing with Vue 3 and TypeScript in Vite. The template uses Vue 3, Vite, Vuetify, Vue Router, and TypeScript.
+Code for the lichess stats visualizer. The app is not available yet.
+
+# Development
 
 ## Recommended IDE Setup
 


### PR DESCRIPTION
The documentation after recommended IDE Setup has been kept and put under a Development chapter